### PR TITLE
Implemented Menus by Date API at /api/menus_by_date

### DIFF
--- a/colonialsite/colonialsite/dummy_settings.py
+++ b/colonialsite/colonialsite/dummy_settings.py
@@ -37,7 +37,7 @@ JUNIOR_YEAR = '2018'
 SENIOR_YEAR = '2017'
 
 # Used in coloauth.middleware
-# Default Login is automatically added 
+# Default Login is automatically added
 # in RE format
 LOGIN_EXEMPT_URLS = [r'^accounts/logout($|.*)', r'^staff/login($|.*)', r'^staff/logout($|.*)',]
 
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'cas',
+    'django_filters',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -89,8 +90,9 @@ AUTHENTICATION_BACKENDS = (
 CAS_SERVER_URL = 'https://fed.princeton.edu/cas/'
 
 REST_FRAMEWORK = {
-        'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
-        'PAGE_SIZE': 10
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
+    'PAGE_SIZE': 10,
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
 }
 
 ROOT_URLCONF = 'colonialsite.urls'

--- a/colonialsite/colonialsite/urls.py
+++ b/colonialsite/colonialsite/urls.py
@@ -33,7 +33,7 @@ router.register(r'api/menu_categories', MenuCategoryViewSet)
 urlpatterns = [
     url(r'^', include('dashboard.urls', namespace='dashboard')),
     url(r'^admin/', admin.site.urls),
-    
+
     #url(r'^reservations/', include('reservations.urls')),
     url(r'^menus/', include('menus.urls')),
     url(r'^events/', include('events.urls', namespace='events')),
@@ -43,6 +43,7 @@ urlpatterns = [
     #url(r'^api/members/', include('members.api_urls', namespace='members_api')),
     url(r'^api/events/', include('events.api_urls', namespace='events_api')),
     url(r'^api/announcements/', include('announcements.api_urls', namespace='announcements_api')),
+    url(r'^api/menus_by_date/', include('menus.api_urls', namespace='menus_by_date_api')),
 
     url(r'^accounts/login/$', cas.views.login, name='login'),
     url(r'^accounts/logout/$', cas.views.logout, name='logout'),

--- a/colonialsite/menus/api_urls.py
+++ b/colonialsite/menus/api_urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from views import MenuCategoryByDate
+
+urlpatterns = [
+    url(r'^$', MenuCategoryByDate.as_view(), name = 'menus_by_date'),
+]

--- a/colonialsite/menus/views.py
+++ b/colonialsite/menus/views.py
@@ -4,7 +4,9 @@ from django.shortcuts import render
 
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
-from rest_framework import viewsets
+from rest_framework import viewsets, generics
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from menus.models import MenuCategory, Dish, Rating
 from menus.serializers import MenuCategorySerializer, DishSerializer, RatingSerializer
@@ -45,3 +47,10 @@ class RatingViewSet(LoginRequiredMixin, viewsets.ModelViewSet):
 class MenuCategoryViewSet(LoginRequiredMixin, viewsets.ModelViewSet):
     queryset = MenuCategory.objects.all().order_by('category')
     serializer_class = MenuCategorySerializer
+
+class MenuCategoryByDate(LoginRequiredMixin, generics.ListAPIView):
+    model = MenuCategory
+    serializer_class = MenuCategorySerializer
+    queryset = MenuCategory.objects.all().order_by('category')
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('date',)


### PR DESCRIPTION
Implements a Menus by Date API with the following usage:

* `GET /api/menus_by_date/?date=yyyy-mm-dd`: returns menus for a certain day only

For example:
<img width="1324" alt="screen shot 2018-02-10 at 9 25 29 pm" src="https://user-images.githubusercontent.com/10209814/36068712-ed77d352-0ea9-11e8-83fd-a1c2cdc24143.png">

The API depends on the `django-filters` package which is already included in `requirements.txt`. We need to make sure `django_filters` is included in `INSTALLED_APPS` in the production `settings.py`, though. Can someone also make any necessary updates to make `dummy_settings.py` closer to the actual production `settings.py`? I've added a default pagination class that I'm guessing is used in production (without it, the `menu_categories` API returns JSON in the wrong format), but there's probably other differences between the prod settings and dev settings.
