### PR TITLE
Rebuilt menu client to use the menus_by_date API + major refactoring

### DIFF
--- a/colonialsite/assets/js/statics/urls.js
+++ b/colonialsite/assets/js/statics/urls.js
@@ -1,7 +1,7 @@
 export const DISHES_LIST = "/api/dishes";
 export const EVENTS_LIST = "/api/events";
 export const MEMBERS_LIST = "/api/members";
-export const MENU_CATEGORY_LIST = "/api/menu_categories";
+export const MENU_CATEGORY_LIST = "/api/menus_by_date";
 
 export const ANNOUNCEMENTS_POST = "/api/announcements/post";
 export const MENU_CATEGORY_POST = MENU_CATEGORY_LIST + "/";


### PR DESCRIPTION
## Changes

* Menu client now exclusively uses the `menus_by_date` API and loads menus on a day-by-day basis

* On page load, today's, yesterday's, and tomorrow's menus are all automatically preloaded

* To reduce redundant requests, once a date is fetched from the API it will never be fetched again for this session

* Deleted most of the `renderDate()` code because [that functionality already exists in Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString)

* Major modularity improvements

## Testing

I manually tested on localhost, including doing the following things:

* Load `/menus`, check network requests to make sure today/yesterday/tomorrow menus all loaded

* Move between today/yesterday/tomorrow to make sure no further redundant network requests go out

* Move to a new date to make sure a network request happens to load the menu for that date

* Click a menu item, rate it, close the dialog to make sure it all still works without errors

* Use the date picker to go to a new date to make sure it works without errors and sends a network request only if necessary

---

How do we deploy to prod @aruchames ? Any other steps to take before pushing this live?