### PR TITLE
Fixed admin site issues from menus_by_date client + misc improvements/fixes

### DIFF
--- a/colonialsite/assets/js/pages/menus/DishEdit.js
+++ b/colonialsite/assets/js/pages/menus/DishEdit.js
@@ -12,12 +12,9 @@ class DishEdit extends Component{
 	}
 	render(){
 		const detail = <DishInputDetails dish={this.props.dish}
-										 
 										 finishSubmit={this.props.closeModal}
 										 menu_id={this.props.menu_id} />
-	 	return (<div>
-	 				{detail}
- 				</div>)
+	 	return <div>{detail}</div>;
 	}
 }
 

--- a/colonialsite/assets/js/pages/menus/DishInput.js
+++ b/colonialsite/assets/js/pages/menus/DishInput.js
@@ -9,14 +9,16 @@ class DishInput extends Component{
 		};
 	}
 
-    loadContentFromServer() {
+    loadContentFromServer(renderMenu) {
         $.ajax({
             url: this.props.url,
             datatype: 'json',
             cache: false,
             success: function(data) {
                 this.setState({data:data.results});
-                this.props.renderMenu()
+                if (renderMenu) {
+                    this.props.renderMenu();
+                }
             }.bind(this)
         })
     }
@@ -24,10 +26,12 @@ class DishInput extends Component{
 	componentDidMount() {
         this.loadContentFromServer();
     }
-	render(){
-		return (<MenuInput updateDishes={this.loadContentFromServer.bind(this)}
-						   dishes={this.state.data}
-						   menu_id={this.props.menu_id}/>)
+	render() {
+		return (
+            <MenuInput updateDishes={this.loadContentFromServer.bind(this, true)}
+    			dishes={this.state.data}
+    			menu_id={this.props.menu_id}/>
+        );
 	}
 }
 export default DishInput;

--- a/colonialsite/assets/js/pages/menus/DishInputDetails.js
+++ b/colonialsite/assets/js/pages/menus/DishInputDetails.js
@@ -51,7 +51,7 @@ class DishInputDetails extends Component {
 		const newMenu = this.props.menu_id;
 
 		const csrftoken = Cookies.get('csrftoken');
-		const post_or_put_dish_menus = dishes.includes(newMenu) ? dishes : dishes.concat(newMenu) 
+		const post_or_put_dish_menus = dishes.includes(newMenu) ? dishes : dishes.concat(newMenu)
 
 		var post_or_put_dish_data =
 		{
@@ -73,9 +73,7 @@ class DishInputDetails extends Component {
 			headers: { "X-CSRFToken": csrftoken},
 			data:post_or_put_dish_data
 		})
-		.then(function(){ 
-			this.props.finishSubmit();
-		}.bind(this))
+		.then(this.props.finishSubmit)
 		.catch(function(jqXHR, textStatus, errorThrown){
 			console.log(textStatus);
 			console.log(jqXHR);
@@ -132,7 +130,7 @@ class DishInputDetails extends Component {
 					</label>
 				</div>
 				<div style={{width:'90%'}}>
-				Allergens: 
+				Allergens:
 					<TextField
 						   value={this.state.allergens}
 						   name={'allergens'}

--- a/colonialsite/assets/js/pages/menus/MealContainer.js
+++ b/colonialsite/assets/js/pages/menus/MealContainer.js
@@ -35,7 +35,7 @@ class MealContainer extends Component {
     this.state = {
       date: props.today.date,
       day: d,
-      data: [],
+      data: {},
       open: false,
       fetchedDates: {}, // stores the timestamp that date was fetched from server
     };
@@ -52,8 +52,8 @@ class MealContainer extends Component {
     this.fetchData(tomorrow);
   }
 
-  fetchData(date) {
-    if (this.state.fetchedDates[date]) {
+  fetchData(date, force) {
+    if (!force && this.state.fetchedDates[date]) {
       // This date has already been fetched, no need to fetch it again.
       return;
     }
@@ -64,7 +64,7 @@ class MealContainer extends Component {
       cache: false,
       success: data => {
         this.setState({
-          data: this.state.data.concat(data.results),
+          data: Object.assign({}, this.state.data, { [date]: data.results }),
           fetchedDates: Object.assign({ [date]: Date.now() }, this.state.fetchedDates),
         });
       },
@@ -132,18 +132,20 @@ class MealContainer extends Component {
   }
 
   getMeals() {
-    const lunch = [];
-    const dinner = [];
-    const brunch = [];
+    let lunch, dinner, brunch;
     const date = this.state.date;
+    const isFetched = this.state.fetchedDates[date];
 
-    this.state.data.map(mealCategory => {
-      if (mealCategory.date === date) {
+    if (isFetched) {
+      lunch = [];
+      dinner = [];
+      brunch = [];
+      this.state.data[date].forEach(mealCategory => {
         if (mealCategory.meal === "Lunch") lunch.push(mealCategory);
         else if (mealCategory.meal === "Dinner") dinner.push(mealCategory);
         else if (mealCategory.meal === "Brunch") brunch.push(mealCategory);
-      }
-    });
+      });
+    }
 
     if (this.state.day > 5) {
       if (this.props.edit) {

--- a/colonialsite/assets/js/pages/menus/MenuInput.js
+++ b/colonialsite/assets/js/pages/menus/MenuInput.js
@@ -37,12 +37,12 @@ class MenuInput extends Component {
 				    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
 			});
 
-		  	// Certain minor words should be left lowercase unless 
+		  	// Certain minor words should be left lowercase unless
 	  		// they are the first or last words in the string
-			lowers = ['A', 'An', 'The', 'And', 'But', 'Or', 'For', 'Nor', 'As', 'At', 
+			lowers = ['A', 'An', 'The', 'And', 'But', 'Or', 'For', 'Nor', 'As', 'At',
 	  		'By', 'For', 'From', 'In', 'Into', 'Near', 'Of', 'On', 'Onto', 'To', 'With'];
 	  		for (i = 0, j = lowers.length; i < j; i++)
-				str = str.replace(new RegExp('\\s' + lowers[i] + '\\s', 'g'), 
+				str = str.replace(new RegExp('\\s' + lowers[i] + '\\s', 'g'),
 	      	function(txt) {
 	        	return txt.toLowerCase();
 	      	});
@@ -50,7 +50,7 @@ class MenuInput extends Component {
 	  		// Certain words such as initialisms or acronyms should be left uppercase
 	  		uppers = ['Id', 'Tv'];
 	  		for (i = 0, j = uppers.length; i < j; i++)
-	    		str = str.replace(new RegExp('\\b' + uppers[i] + '\\b', 'g'), 
+	    		str = str.replace(new RegExp('\\b' + uppers[i] + '\\b', 'g'),
 	      				uppers[i].toUpperCase());
 
 	  		return str;
@@ -77,7 +77,7 @@ class MenuInput extends Component {
 							   dataSourceConfig={{text:'name', value:'id'}}
 							   openOnFocus={true}
 							   fullWidth={true}
-							   searchText={this.state.searchText}	
+							   searchText={this.state.searchText}
 							   listStyle={{ maxHeight: 200, overflow: 'auto' }}
 							   floatingLabelText={"Add New Dish"}
 							   onUpdateInput={this.handleUpdate.bind(this)}
@@ -88,7 +88,7 @@ class MenuInput extends Component {
 	            </form>
 			</div>
 		)
-	}	
+	}
 }
 
 export default MenuInput;

--- a/colonialsite/assets/js/statics/urls.js
+++ b/colonialsite/assets/js/statics/urls.js
@@ -4,7 +4,7 @@ export const MEMBERS_LIST = "/api/members";
 export const MENU_CATEGORY_LIST = "/api/menus_by_date";
 
 export const ANNOUNCEMENTS_POST = "/api/announcements/post";
-export const MENU_CATEGORY_POST = MENU_CATEGORY_LIST + "/";
+export const MENU_CATEGORY_POST = "/api/menu_categories/";
 export const RATING_POST = "/api/ratings/";
 export const DISH_POST = "/api/dishes/";
 


### PR DESCRIPTION
## Changes

* Admin site now correctly uses the new `fetchData()` from #14 

* Removed / fixed a ton of extraneous or redundant network requests - server load should be way lower now

* Readability / style fixes

## Testing

* Clean database, login as staff, make sure menu categories are automatically created

* Add dish on client, make sure the dish immediately shows up without having to refresh the page

* Add dishes on client, make sure the dishes still show up after refreshing the page

* Add dishes, switch to the non-staff `/menus` page and make sure the dishes show up

* Repeat all the above but after navigating through the calendar